### PR TITLE
MM-230 Use common panel to display search results and include # of co-ops filtered

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -43,7 +43,7 @@ mykomap's repository:
 Install the prerequisites
 
 	apt install php php-curl rsync # On Debian
-	npm run install
+	npm install
 	
 Run the development web server in the background (do this in a separate console):
 

--- a/src/map-app/app/map-ui.ts
+++ b/src/map-app/app/map-ui.ts
@@ -48,7 +48,7 @@ export class MapUI {
       });
     };
 
-    EventBus.Directory.initiativeClicked.sub(initiative => this.onInitiativeClickedInSidebar(initiative));
+    EventBus.Map.resetSearch.sub(() => this.resetSearch());
   }
 
   // This inspects the config and constructs an appropriate set of

--- a/src/map-app/app/map-ui.ts
+++ b/src/map-app/app/map-ui.ts
@@ -8,7 +8,7 @@ import { EventBus } from "../eventbus";
 import "./map"; // Seems to be needed to prod the leaflet CSS into loading.
 import { SidebarPresenter } from "./presenter/sidebar";
 import { PhraseBook } from "../localisations";
-import { toString as _toString } from '../utils';
+import { toString as _toString, canDisplayExpandedSidebar } from '../utils';
 import { Action, AppState, PropEquality, StateManager, TextSearch } from "./state-manager";
 import { StateChange } from "../undo-stack";
 import { Dictionary } from "../common-types";
@@ -48,6 +48,7 @@ export class MapUI {
       });
     };
 
+    EventBus.Map.initiativeClicked.sub(initiative => this.onInitiativeClicked(initiative));
     EventBus.Map.resetSearch.sub(() => this.resetSearch());
   }
 
@@ -131,36 +132,38 @@ export class MapUI {
       throw new Error(`an attempt to add a filter on an unknown propery name '${propName}'`);
 
     const isMulti = propDef.type === 'multi';
-    if (value === undefined)
+    if (value === undefined) {
       this.stateManager.clearPropFilter(propName);
-    else
+    } else {
       this.stateManager.propFilter(new PropEquality(propName, value, isMulti));
+    }
+
+    if (canDisplayExpandedSidebar()) // on smaller screens, wait until user clicks Apply Filters
+      EventBus.Sidebar.showInitiativeList.pub();
   }
 
   isSelected(initiative: Initiative): boolean {
-    // Currently unimplemented - I can see an sea-initiative-active class
-    // being applied if a test was true, but it makes no sense in the current
-    // context AFAICT. The test was:
-    // initiative === this.contextStack.current()?.initiatives[0]
-
-    // The main thing is seemed to do is highlight an initiative (or
-    // initiatives) in the directory pop-out list of initiatives in a
-    // category.
-    
-    // For now, just return false always. We may re-implement this later.
-    return false; 
+    const selectedInitiatives = this.mapPresenter?.getSelectedInitiatives() ?? [];
+    return  selectedInitiatives.includes(initiative);
   }
 
   toggleSelectInitiative(initiative: Initiative) {
-    // Currently unimplemented.
+    const selectedInitiatives = this.mapPresenter?.getSelectedInitiatives() ?? [];
     
-    // EventBus.Markers.needToShowLatestSelection.pub(lastContent.initiatives);
+    if (selectedInitiatives.includes(initiative)) {
+      EventBus.Markers.needToShowLatestSelection.pub(selectedInitiatives.filter(i => i !== initiative));
+    } else {
+      EventBus.Markers.needToShowLatestSelection.pub([...selectedInitiatives, initiative]);
+    }
   }
-
 
   performSearch(text: string) {
     console.log("Search submitted: [" + text + "]");
     this.stateManager.textSearch(new TextSearch(text));
+
+    if (canDisplayExpandedSidebar()) {// on smaller screens, wait until user clicks Apply Filters
+      EventBus.Sidebar.showInitiativeList.pub();
+    }
   }
 
   // Text to show in the search box
@@ -182,26 +185,40 @@ export class MapUI {
   }
 
   private refreshSidebar() {
-    this.getSidebarPresenter(this).then((presenter) => presenter.changeSidebar());
+    this.getSidebarPresenter(this).then((presenter) => {
+      presenter.changeSidebar();
+    });
   }
 
-
-
-  private notifyMapNeedsToNeedsToBeZoomedAndPannedOneInitiative(initiative: Initiative) {
-    const data = EventBus.Map.mkSelectAndZoomData([initiative]);
-    EventBus.Map.needsToBeZoomedAndPanned.pub(data);
+  private notifyMapNeedsToNeedsToSelectAndZoomOnInitiative(initiative: Initiative) {
+    const maxZoom = this.config.getMaxZoomOnOne();
+    const defaultPos = this.config.getDefaultLatLng();
+    
+    const data = EventBus.Map.mkSelectAndZoomData([initiative], { maxZoom, defaultPos });
+    EventBus.Map.selectAndZoomOnInitiative.pub(data);
   }
   
-  private onInitiativeClickedInSidebar(initiative?: Initiative) {
-    if (!initiative)
-      return;
+  private onInitiativeClicked(initiative?: Initiative) {
+    console.log('Clicked', initiative);
     
-    //this.parent.mapui.stateManager.append(new SearchResults([initiative]));
-    //console.log(this.parent.mapui.stateManager.current());
+    if (initiative) {
+      // Move the window to the right position first
+      this.notifyMapNeedsToNeedsToSelectAndZoomOnInitiative(initiative);
+      this.refreshSidebar();
+      // Populate the sidebar and highlight the intiative in the directory
+      this.getSidebarPresenter(this).then((presenter) => {
+        presenter.populateInitiativeSidebar(
+          initiative,
+          this.markers.getInitiativeContent(initiative) ?? ''
+        );
+      });
+    }
+    else {
+      // User has deselected
+      EventBus.Markers.needToShowLatestSelection.pub([]);
+    }
 
-    this.notifyMapNeedsToNeedsToBeZoomedAndPannedOneInitiative(initiative);
     this.refreshSidebar();
-    EventBus.Initiative.searchedInitiativeClicked.pub(initiative);
   }
 
   currentItem() {

--- a/src/map-app/app/map-ui.ts
+++ b/src/map-app/app/map-ui.ts
@@ -49,7 +49,7 @@ export class MapUI {
     };
 
     EventBus.Map.initiativeClicked.sub(initiative => this.onInitiativeClicked(initiative));
-    EventBus.Map.resetSearch.sub(() => this.resetSearch());
+    EventBus.Map.clearFiltersAndSearch.sub(() => this.clearFiltersAndSearch());
   }
 
   // This inspects the config and constructs an appropriate set of
@@ -114,8 +114,8 @@ export class MapUI {
     this.stateManager.clearPropFilter(filterName);
   }
 
-  resetSearch(): void {
-    this.stateManager.reset();
+  clearFiltersAndSearch(): void {
+    this.stateManager.clearFiltersAndSearch();
   }
 
   /// Returns a list of property values matching the given filter

--- a/src/map-app/app/presenter/map.ts
+++ b/src/map-app/app/presenter/map.ts
@@ -8,7 +8,7 @@ import { MapUI } from '../map-ui';
 
 export class MapPresenter extends BasePresenter {
   readonly view: MapView;
-  private previouslySelected: Initiative[] = [];
+  private currentlySelected: Initiative[] = [];
   
   constructor(readonly mapUI: MapUI) {
     super();
@@ -35,7 +35,7 @@ export class MapPresenter extends BasePresenter {
     EventBus.Initiatives.loadStarted.sub(() => this.onInitiativeLoadMessage());
     EventBus.Initiatives.loadFailed.sub(error => this.onInitiativeLoadMessage(error));
     
-    EventBus.Markers.needToShowLatestSelection.sub(initiative => this.onMarkersNeedToShowLatestSelection(initiative));
+    EventBus.Markers.needToShowLatestSelection.sub(initiatives => this.onMarkersNeedToShowLatestSelection(initiatives));
     EventBus.Map.needsToBeZoomedAndPanned.sub(data => this.onMapNeedsToBeZoomedAndPanned(data));
     EventBus.Map.needToShowInitiativeTooltip.sub(initiative => this.onNeedToShowInitiativeTooltip(initiative));
     EventBus.Map.needToHideInitiativeTooltip.sub(initiative => this.onNeedToHideInitiativeTooltip(initiative));
@@ -49,7 +49,7 @@ export class MapPresenter extends BasePresenter {
   }
     
   onInitiativeClicked() {
-    EventBus.Directory.initiativeClicked.pub(undefined);
+    EventBus.Map.initiativeClicked.pub(undefined);
   }
 
   onLoad() {
@@ -96,11 +96,11 @@ export class MapPresenter extends BasePresenter {
   }
 
   onMarkersNeedToShowLatestSelection(selected: Initiative[]) {
-    this.previouslySelected.forEach((initiative) => {
+    this.currentlySelected.forEach((initiative) => {
       this.mapUI.markers.setUnselected(initiative);
     });
 
-    this.previouslySelected = selected;
+    this.currentlySelected = selected;
     
     //zoom in and then select 
     selected.forEach((initiative) => {
@@ -144,4 +144,7 @@ export class MapPresenter extends BasePresenter {
     this.view.selectAndZoomOnInitiative(data);
   }
 
+  getSelectedInitiatives(): Initiative[] {
+    return this.currentlySelected;
+  }
 }

--- a/src/map-app/app/presenter/sidebar.ts
+++ b/src/map-app/app/presenter/sidebar.ts
@@ -1,6 +1,7 @@
 import { Dictionary } from '../../common-types';
 import { EventBus } from '../../eventbus';
 import { MapUI } from '../map-ui';
+import { Initiative } from '../model/initiative';
 import { SidebarView } from '../view/sidebar';
 import { BasePresenter } from './base';
 import { AboutSidebarPresenter } from './sidebar/about';
@@ -63,7 +64,7 @@ export class SidebarPresenter extends BasePresenter {
     if (name !== undefined) {
       // If name is set, change the current sidebar and then refresh
       this.sidebarName = name;
-      this.children[this.sidebarName]?.refreshView();
+      this.children[this.sidebarName]?.refreshView(true);
     }
     else {
       // Just refresh the currently showing sidebar.
@@ -76,11 +77,13 @@ export class SidebarPresenter extends BasePresenter {
           return; // No sidebars? Can't do anything.
       }
         
-      this.children[this.sidebarName]?.refreshView();
+      this.children[this.sidebarName]?.refreshView(false);
     }
   }
 
   showSidebar() {
+    // Refresh the view before showing
+    this.children[this.sidebarName ?? 'undefined']?.refreshView(true);
     this.view.showSidebar();
   }
 
@@ -95,6 +98,14 @@ export class SidebarPresenter extends BasePresenter {
 
   hideInitiativeSidebar() {
     this.view.hideInitiativeSidebar();
+  }
+
+  populateInitiativeSidebar(initiative: Initiative, initiativeContent: string) {
+    this.view.populateInitiativeSidebar(initiative, initiativeContent);
+  }
+
+  showInitiativeList() {
+    this.view.showInitiativeList();
   }
 
   hideInitiativeList() {
@@ -112,7 +123,7 @@ export class SidebarPresenter extends BasePresenter {
     });
     EventBus.Sidebar.showDirectory.sub(() => {
       this.changeSidebar("directory");
-      this.view.showInitiativeList();
+      this.showSidebar();
     });
     EventBus.Sidebar.showDatasets.sub(() => {
       this.changeSidebar("datasets");
@@ -121,8 +132,12 @@ export class SidebarPresenter extends BasePresenter {
     EventBus.Sidebar.showSidebar.sub(() => this.showSidebar());
     EventBus.Sidebar.hideSidebar.sub(() => this.hideSidebar());
     EventBus.Sidebar.hideInitiativeSidebar.sub(() => this.hideInitiativeSidebar());
+    EventBus.Sidebar.showInitiativeList.sub(() => this.showInitiativeList());
     EventBus.Sidebar.hideInitiativeList.sub(() => this.hideInitiativeList());
-    EventBus.Initiatives.reset.sub(() => this.changeSidebar());
+    EventBus.Initiatives.reset.sub(() => {
+      this.changeSidebar();
+      this.hideInitiativeList();
+    });
     EventBus.Initiatives.loadComplete.sub(() => this.changeSidebar());
   }
 

--- a/src/map-app/app/presenter/sidebar/base.ts
+++ b/src/map-app/app/presenter/sidebar/base.ts
@@ -3,6 +3,7 @@ import { BasePresenter }from '../base';
 import { BaseSidebarView } from '../../view/sidebar/base';
 import { SidebarPresenter } from '../sidebar';
 import { Initiative } from '../../model/initiative';
+import { canDisplayExpandedSidebar } from '../../../utils';
 
 export interface NavigationCallback {
   disabled: boolean;
@@ -21,8 +22,12 @@ export abstract class BaseSidebarPresenter extends BasePresenter {
    * If the sidebar wants to do something more than to get its view to refresh when the history
    * buttons have been used, then it should override this definition with its own.
    */
-  historyButtonsUsed(): void {    
+  historyButtonsUsed(): void {
     this.view.refresh(false);
+
+    // Show the results pane again, since there have been changes
+    if (canDisplayExpandedSidebar()) // on smaller screens, wait until user clicks Apply Filters
+      EventBus.Sidebar.showInitiativeList.pub();
   }
 
   deselectInitiatives(): void {

--- a/src/map-app/app/presenter/sidebar/base.ts
+++ b/src/map-app/app/presenter/sidebar/base.ts
@@ -17,10 +17,12 @@ export abstract class BaseSidebarPresenter extends BasePresenter {
     super();
   }
   
-  // If the sidebar wants to do something more than to get its view to refresh when the history buttons have been used, then
-  // it should override this definition with its own:
+  /**
+   * If the sidebar wants to do something more than to get its view to refresh when the history
+   * buttons have been used, then it should override this definition with its own.
+   */
   historyButtonsUsed(): void {    
-    this.view.refresh();
+    this.view.refresh(false);
   }
 
   deselectInitiatives(): void {
@@ -49,6 +51,15 @@ export abstract class BaseSidebarPresenter extends BasePresenter {
     this.historyButtonsUsed();
   }
 
+  /**
+   * Refreshes the sidebar view
+   * 
+   * @param changed true if we changed to this sidebar, false if it was already showing and we're
+   * just refreshing it.
+   */
+  refreshView(changed: boolean) {
+    this.view.refresh(changed);
+  }
 
   onInitiativeClicked(initiative: Initiative): void {
     EventBus.Map.initiativeClicked.pub(initiative);

--- a/src/map-app/app/presenter/sidebar/base.ts
+++ b/src/map-app/app/presenter/sidebar/base.ts
@@ -2,6 +2,7 @@ import { EventBus } from '../../../eventbus';
 import { BasePresenter }from '../base';
 import { BaseSidebarView } from '../../view/sidebar/base';
 import { SidebarPresenter } from '../sidebar';
+import { Initiative } from '../../model/initiative';
 
 export interface NavigationCallback {
   disabled: boolean;
@@ -48,9 +49,17 @@ export abstract class BaseSidebarPresenter extends BasePresenter {
     this.historyButtonsUsed();
   }
 
-  /// Refreshes the view
-  refreshView() {
-    this.view.refresh();
+
+  onInitiativeClicked(initiative: Initiative): void {
+    EventBus.Map.initiativeClicked.pub(initiative);
+  }
+
+  onInitiativeMouseoverInSidebar(initiative: Initiative): void {
+    EventBus.Map.needToShowInitiativeTooltip.pub(initiative);
+  }
+
+  onInitiativeMouseoutInSidebar(initiative: Initiative): void {
+    EventBus.Map.needToHideInitiativeTooltip.pub(initiative);
   }
 }
 

--- a/src/map-app/app/presenter/sidebar/directory.ts
+++ b/src/map-app/app/presenter/sidebar/directory.ts
@@ -1,7 +1,6 @@
 import { EventBus } from '../../../eventbus';
 import { DirectorySidebarView } from '../../view/sidebar/directory';
 import { BaseSidebarPresenter } from './base';
-import { Initiative } from '../../model/initiative';
 import { SidebarPresenter } from '../sidebar';
 
 export class DirectorySidebarPresenter extends BaseSidebarPresenter {
@@ -18,89 +17,6 @@ export class DirectorySidebarPresenter extends BaseSidebarPresenter {
       //todo reload new ones inside instead (without closing)
       EventBus.Sidebar.hideInitiativeList.pub();
     });
-    EventBus.Directory.initiativeClicked.sub(initiative => this.initiativeClicked(initiative));
-  }
-
-  notifyViewToBuildDirectory(): void {
-    this.view.refresh();
-  }
-
-  // Gets the initiatives with a selection key, or if absent, gets all the initiatives
-  getInitiativesForFieldAndSelectionKey(propName: string, key?: string): Initiative[] {
-    if (key == null)
-      return this.parent.mapui.dataServices.getAggregatedData().loadedInitiatives;
-    else
-      return this.parent.mapui.dataServices.getAggregatedData().registeredValues[propName]?.[key] ?? [];
-  }
-
-  notifyMapNeedsToNeedsToBeZoomedAndPanned(initiatives: Initiative[]): void {
-    if (initiatives.length <= 0)
-      return;
-    const data = EventBus.Map.mkSelectAndZoomData(initiatives, { maxZoom: this.parent.mapui.config.getMaxZoomOnGroup() });
-    EventBus.Map.needsToBeZoomedAndPanned.pub(data);
-  }
-
-  notifyMapNeedsToNeedsToSelectInitiative(initiatives: Initiative[]): void {
-    if (initiatives.length == 0)
-      return;
-    
-    const maxZoom = initiatives.length === 1? this.parent.mapui.config.getMaxZoomOnGroup() : undefined;
-    const defaultPos = this.parent.mapui.config.getDefaultLatLng();
-    
-    const data = EventBus.Map.mkSelectAndZoomData(initiatives, { maxZoom, defaultPos });
-    EventBus.Map.selectAndZoomOnInitiative.pub(data);
-  }
-
-  onInitiativeMouseoverInSidebar(initiative: Initiative): void {
-    EventBus.Map.needToShowInitiativeTooltip.pub(initiative);
-  }
-  onInitiativeMouseoutInSidebar(initiative: Initiative): void {
-    EventBus.Map.needToHideInitiativeTooltip.pub(initiative);
-  }
-
-  clearLatestSelection() {
-    EventBus.Markers.needToShowLatestSelection.pub([]);
-  }
-
-  removeFilters(filterName?: string) {
-    //remove specific filter
-    if (filterName) {
-      this.parent.mapui.removeFilter(filterName);
-    }
-    else {
-      //remove all filters
-      this.parent.mapui.removeFilters();
-    }
-    this.view.d3selectAndClear(
-      "#sea-initiatives-list-sidebar-content"
-    );
-    //clear the window
-    EventBus.Sidebar.hideInitiativeList.pub();
-    this.clearLatestSelection();
-  }
-
-  initiativeClicked(initiative?: Initiative): void {
-    if (initiative) {
-      //this.parent.contentStack.append(new SearchResults([initiative]));
-      // Move the window to the right position first
-      this.notifyMapNeedsToNeedsToSelectInitiative([initiative]);
-
-      // Populate the sidebar and hoghlight the iitiative in the directory
-      this.view.populateInitiativeSidebar(
-        initiative,
-        this.parent.mapui.markers.getInitiativeContent(initiative) ?? ''
-      );
-
-    }
-    else {
-      // User has deselected
-      // TODO: This probably shouldn\t be here
-      EventBus.Markers.needToShowLatestSelection.pub([]);
-      // Deselect the sidebar and hoghlight the iitiative in the directory
-      this.view.deselectInitiativeSidebar();
-
-      //doesn't do much?
-    }
   }
 
   // This gets the localised 'allEntries' label in all cases.

--- a/src/map-app/app/presenter/sidebar/initiatives.ts
+++ b/src/map-app/app/presenter/sidebar/initiatives.ts
@@ -35,10 +35,6 @@ export class InitiativesSidebarPresenter extends BaseSidebarPresenter {
     this.parent.mapui.performSearch(text);
   }
 
-  resetSearch() {
-    this.parent.mapui.resetSearch();
-  }
-
   changeSearchText(txt: string) {
     this.view.changeSearchText(txt);
   }

--- a/src/map-app/app/presenter/sidebar/initiatives.ts
+++ b/src/map-app/app/presenter/sidebar/initiatives.ts
@@ -1,9 +1,8 @@
 import { EventBus } from '../../../eventbus';
 import { InitiativesSidebarView } from '../../view/sidebar/initiatives';
 import { BaseSidebarPresenter } from './base';
-import { SearchResults } from '../../../search-results';
 import { Initiative } from '../../model/initiative';
-import { compactArray, toString as _toString } from '../../../utils';
+import { toString as _toString } from '../../../utils';
 import { SidebarPresenter } from '../sidebar';
 
 export class InitiativesSidebarPresenter extends BaseSidebarPresenter {
@@ -11,7 +10,6 @@ export class InitiativesSidebarPresenter extends BaseSidebarPresenter {
   
   _eventbusRegister(): void {
     EventBus.Marker.selectionToggled.sub(initiative => this.onMarkerSelectionToggled(initiative));
-    EventBus.Initiative.searchedInitiativeClicked.sub(initiative => this.searchedInitiativeClicked(_toString(initiative.uri, undefined)));
   }
 
   constructor(readonly parent: SidebarPresenter) {
@@ -27,44 +25,10 @@ export class InitiativesSidebarPresenter extends BaseSidebarPresenter {
   changeFilters(propName: string, value?: string) {
     this.parent.mapui.changeFilters(propName, value);
   }
-  
-  notifyShowInitiativeTooltip(initiative: Initiative) {
-    EventBus.Map.needToShowInitiativeTooltip.pub(initiative);
-  }
 
-  notifyHideInitiativeTooltip(initiative: Initiative) {
-    EventBus.Map.needToHideInitiativeTooltip.pub(initiative);
-  }
-
-  historyButtonsUsed() {
-    //console.log("sidebar/initiatives historyButtonsUsed");
-    //console.log(lastContent);
-    //this.notifyMarkersNeedToShowNewSelection(lastContent);
-    this.view.refresh();
-  }
-
-  initClicked(initiative: Initiative) {
-    EventBus.Directory.initiativeClicked.pub(initiative);
-    if (window.outerWidth <= 800) {
-      EventBus.Directory.initiativeClickedHideSidebar.pub(initiative);
-    }
-  }
-  
-  onInitiativeMouseoverInSidebar(initiative: Initiative) {
-    this.notifyShowInitiativeTooltip(initiative);
-  }
-
-  onInitiativeMouseoutInSidebar(initiative: Initiative) {
-    this.notifyHideInitiativeTooltip(initiative);
-  }
-  
   onMarkerSelectionToggled(initiative: Initiative) {
     this.parent.mapui.toggleSelectInitiative(initiative);
-    this.view.refresh();
-  }
-
-  searchedInitiativeClicked(uri?: string) {
-    if (uri) this.view.onInitiativeClicked(uri);
+    this.view.refresh(false);
   }
 
   performSearch(text: string) {

--- a/src/map-app/app/state-manager.ts
+++ b/src/map-app/app/state-manager.ts
@@ -138,10 +138,6 @@ export class AppState {
     );
     return new AppStateChange(textSearch, result);
   }
-
-  clearTextSearch(): AppStateChange|undefined {
-    return this.addTextSearch(new TextSearch(''));
-  }
   
   addPropEquality(propEq: PropEquality): AppStateChange|undefined {
     const oldPropFilter = this.propFilters[propEq.propName];
@@ -199,6 +195,17 @@ export class AppState {
       this.textSearch
     );
     return new AppStateChange(action, result);
+  }
+
+  removePropEqualitiesAndClearTextSearch(): AppStateChange|undefined {
+    if (Object.keys(this.propFilters).length === 0 && this.textSearch.searchText === '')
+      return undefined; // No change
+    
+    const result = new AppState(
+      this.allInitiatives,
+      this.allInitiatives
+    );
+    return new AppStateChange(undefined, result);
   }
 }
 
@@ -335,10 +342,6 @@ export class StateManager {
     this.onChange(stateChange);
   }
 
-  clearTextSearch(): void {
-    return this.textSearch(new TextSearch(''));
-  }
-
   propFilter(propEq: PropEquality): void {
     const stateChange = this.stack.current.result.addPropEquality(propEq);
     if (stateChange === undefined)
@@ -357,6 +360,14 @@ export class StateManager {
 
   clearPropFilters(): void {
     const stateChange = this.stack.current.result.removePropEqualities();
+    if (stateChange === undefined)
+      return; // No change
+    this.stack.push(stateChange);
+    this.onChange(stateChange);
+  }
+
+  clearFiltersAndSearch(): void {
+    const stateChange = this.stack.current.result.removePropEqualitiesAndClearTextSearch();
     if (stateChange === undefined)
       return; // No change
     this.stack.push(stateChange);

--- a/src/map-app/app/state-manager.ts
+++ b/src/map-app/app/state-manager.ts
@@ -59,7 +59,7 @@ export class AppState {
   static applyTextSearch(initiatives: Set<Initiative>, textSearch?: TextSearch): Set<Initiative> {
     if (!textSearch)
       return initiatives;
-    if (textSearch.willMatch())
+    if (textSearch.isEmpty())
       return initiatives;
     return filterSet(initiatives, textSearch.predicate);
   }
@@ -120,7 +120,7 @@ export class AppState {
   }
   
   get hasTextSearch(): boolean {
-    return this.textSearch.willMatch();
+    return !this.textSearch.isEmpty();
   }
   
   addTextSearch(textSearch: TextSearch): AppStateChange|undefined {
@@ -233,7 +233,7 @@ export class TextSearch {
       .trim();                  // trim whitespace from front and back
   }
 
-  willMatch() {
+  isEmpty() {
     return this.normSearchText === '';
   }
 }

--- a/src/map-app/app/view/map.ts
+++ b/src/map-app/app/view/map.ts
@@ -9,7 +9,7 @@ import { EventBus } from "../../eventbus";
 import { MarkerManager } from "../marker-manager";
 import { PhraseBook } from "../../localisations";
 import { Box2d } from "../../common-types";
-import { isFiniteBox2d } from "../../utils";
+import { getViewportWidth, isFiniteBox2d } from "../../utils";
 
 export class MapView extends BaseView {
   readonly map: Map;
@@ -188,7 +188,7 @@ export class MapView extends BaseView {
       
       this.map.zoomControl.setPosition("bottomright");
 
-      this.map.on('click', (e) => this.onInitiativeClicked(e));
+      this.map.on('click', (e) => this.onMapClicked(e));
       this.map.on('load', (e) => this.onLoad(e));
       this.map.on('resize', (e) => this.onResize(e));
       
@@ -221,7 +221,7 @@ export class MapView extends BaseView {
     }
   }
 
-  private onInitiativeClicked(me: leaflet.LeafletMouseEvent): void {
+  private onMapClicked(me: leaflet.LeafletMouseEvent): void {
     // Deselect any selected markers        
     if (me.originalEvent.ctrlKey && me.latlng) {
       MapView.copyTextToClipboard(me.latlng.lat + "," + me.latlng.lng);
@@ -235,7 +235,7 @@ export class MapView extends BaseView {
   
   private onResize(_: leaflet.ResizeEvent) {
     this.map.invalidateSize();
-    console.log("Map resize", window.outerWidth);
+    console.log("Map resize", getViewportWidth());
   }
 
   fitBounds(data: EventBus.Map.BoundsData) {

--- a/src/map-app/app/view/map/marker.ts
+++ b/src/map-app/app/view/map/marker.ts
@@ -119,16 +119,13 @@ export class MapMarkerView extends BaseView {
       this.presenter.notifySelectionToggled(this.presenter.initiative);
     } else {
       console.log(this.presenter.initiative);
-      // this.presenter.notifySelectionSet(this.initiative);
-      EventBus.Directory.initiativeClicked.pub(this.presenter.initiative);
+      EventBus.Map.initiativeClicked.pub(this.presenter.initiative);
     }
   }
 
   setUnselected(initiative: Initiative) {
     //close pop-up
     this.presenter.mapUI.map?.closePopup();
-    //close information on the left hand side (for smaller screens)
-    EventBus.Sidebar.hideInitiative.pub();
     //reset the map vars and stop the zoom event from triggering selectInitiative ({target}) method
 
     //change the color of an initiative with a location
@@ -210,7 +207,7 @@ export class MapMarkerView extends BaseView {
     let deselectInitiative = (e: leaflet.LeafletEvent) => {
       if (factory.geoClusterGroup.getVisibleParent(marker) !== marker) {
         this.setUnselected(initiative);
-        EventBus.Directory.initiativeClicked.pub(undefined); // deselects
+        EventBus.Map.initiativeClicked.pub(undefined); // deselects
         factory.geoClusterGroup.off("animationend", deselectInitiative);
       }
     }

--- a/src/map-app/app/view/sidebar.ts
+++ b/src/map-app/app/view/sidebar.ts
@@ -45,7 +45,7 @@ export class SidebarView extends BaseView {
       .attr("class", "w3-button w3-border-0 ml-auto")
       .attr("title", labels.showDirectory)
       .on("click", () => {
-        this.presenter.mapui.resetSearch();
+        this.presenter.mapui.clearFiltersAndSearch();
         this.hideInitiativeList();
         this.presenter.changeSidebar("directory");
 

--- a/src/map-app/app/view/sidebar/base.ts
+++ b/src/map-app/app/view/sidebar/base.ts
@@ -13,8 +13,6 @@ export abstract class BaseSidebarView extends BaseView {
   static readonly accordionClasses =
     "w3-bar-item w3-tiny w3-light-grey w3-padding-small" + BaseSidebarView.hoverColour;
   static readonly sectionClasses = "w3-bar-item w3-small w3-white w3-padding-small";
-
-
   
   abstract readonly presenter: BaseSidebarPresenter;
   
@@ -85,10 +83,17 @@ export abstract class BaseSidebarView extends BaseView {
     }
   }
 
-  refresh() {
+  /**
+   * Refreshes the sidebar view
+   * 
+   * @param changed true if we changed to this sidebar, false if it was already showing and we're
+   * just refreshing it.
+   */
+  refresh(changed: boolean) {
     this.loadFixedSection();
     this.loadHistoryNavigation(); // back and forward buttons
     this.loadScrollableSection();
+    this.refreshSearchResults();
   }
 
   /**

--- a/src/map-app/app/view/sidebar/base.ts
+++ b/src/map-app/app/view/sidebar/base.ts
@@ -149,9 +149,9 @@ export abstract class BaseSidebarView extends BaseView {
         .attr("class", "w3-button w3-border-0 mobile-only")
         .attr("title", labels.showDirectory)
         .on("click", function () {
+          EventBus.Map.clearFiltersAndSearch.pub();
           EventBus.Sidebar.hideInitiativeList.pub();
           EventBus.Sidebar.showDirectory.pub();
-          EventBus.Map.resetSearch.pub();
           EventBus.Markers.needToShowLatestSelection.pub([]);
         })
         .append("i")
@@ -177,8 +177,8 @@ export abstract class BaseSidebarView extends BaseView {
       .attr("class", "ml-auto clear-filters-button")
       .text(labels.clearFilters)
       .on("click", () => {
+        EventBus.Map.clearFiltersAndSearch.pub();
         EventBus.Sidebar.hideInitiativeList.pub();
-        EventBus.Map.resetSearch.pub();
         EventBus.Markers.needToShowLatestSelection.pub([]);
       })
   }

--- a/src/map-app/app/view/sidebar/directory.ts
+++ b/src/map-app/app/view/sidebar/directory.ts
@@ -68,11 +68,11 @@ export class DirectorySidebarView extends BaseSidebarView {
       d3.selectAll("li.sea-directory-field").attr("hidden", null);
     else {
       const a = d3.selectAll("li.sea-directory-field");
-      a.attr("hidden", null); // Hide everything
+      a.attr("hidden", true); // Hide everything
       a.filter(function () {
         // Unhide elements which have matching text
         return d3.select(this).text().toLowerCase().includes(input);
-      }).attr("hidden", true);
+      }).attr("hidden", null);
       //appear and set dissapear after seconds 
       //cancel last dissapear if new one is coming in
       d3.select("#dir-filter")
@@ -88,9 +88,7 @@ export class DirectorySidebarView extends BaseSidebarView {
 
       // dissapear in 1 sec
       this.dissapear = window.setTimeout(dissapear, 1000);
-
     }
-
   }
 
   populateScrollableSelection(selection: d3Selection) {

--- a/src/map-app/app/view/sidebar/directory.ts
+++ b/src/map-app/app/view/sidebar/directory.ts
@@ -27,6 +27,16 @@ export class DirectorySidebarView extends BaseSidebarView {
     this.title = presenter.parent.mapui.labels.directory;
   }
 
+  refresh(changed: boolean) {
+    this.loadHistoryNavigation();
+    if (changed) {
+      // only need to load these if we changed to the directory sidebar
+      this.loadFixedSection();
+      this.loadScrollableSection();
+    }
+    this.refreshSearchResults();
+  }
+
 
   populateFixedSelection(selection: d3Selection): void {
     const that = this;

--- a/src/map-app/app/view/sidebar/directory.ts
+++ b/src/map-app/app/view/sidebar/directory.ts
@@ -6,7 +6,6 @@ import { Initiative } from "../../model/initiative";
 import { DirectorySidebarPresenter } from "../../presenter/sidebar/directory";
 import { d3Selection } from "../d3-utils";
 import { BaseSidebarView } from "./base";
-import { toString as _toString } from "../../../utils";
 import { propDefToVocabUri } from "../../model/data-services";
 
 function uriToTag(uri: string) {
@@ -30,7 +29,6 @@ export class DirectorySidebarView extends BaseSidebarView {
 
 
   populateFixedSelection(selection: d3Selection): void {
-
     const that = this;
     let sidebarTitle = this.title;
     const container = selection
@@ -133,7 +131,8 @@ export class DirectorySidebarView extends BaseSidebarView {
         .classed("sea-directory-field", true)
         .on("click", (event: MouseEvent) => {
           this.presenter.parent.mapui.resetSearch();
-          this.listInitiativesForSelection(propName, propValue); // key may be null
+          this.presenter.parent.mapui.changeFilters(propName, propValue);
+          EventBus.Sidebar.showInitiativeList.pub();
           this.resetFilterSearch();
           d3.select(".sea-field-active").classed("sea-field-active", false);
           if (event.currentTarget instanceof Element)
@@ -164,227 +163,4 @@ export class DirectorySidebarView extends BaseSidebarView {
     if (values)
       addItems(directoryPropName, values);
   }
-
-
-  // selectionKey may be null, for the special 'Every item' case
-  listInitiativesForSelection(propName: string, propValue?: string) {
-    const labels = this.presenter.parent.mapui.labels;
-    const vocabs = this.presenter.parent.mapui.dataServices.getVocabs();
-    const props = this.presenter.parent.mapui.config.fields();
-    const lang = this.presenter.parent.mapui.config.getLanguage();
-    const initiatives = this.presenter.getInitiativesForFieldAndSelectionKey(
-      propName,
-      propValue
-    );
-
-    //deselect all
-    this.presenter.clearLatestSelection();
-
-    this.presenter.notifyMapNeedsToNeedsToBeZoomedAndPanned(initiatives);
-
-    const sidebar = d3.select("#map-app-sidebar");
-    const sidebarButton = d3.select("#map-app-sidebar-button");
-    d3.select(".w3-btn").attr("title", labels.hideDirectory);
-    const initiativeListSidebar = d3.select("#sea-initiatives-list-sidebar");
-    const selection = this.d3selectAndClear("#sea-initiatives-list-sidebar-content");
-    
-    // Add the heading (we need to determine the label as this may be stored in the data or
-    // in the list of values in the presenter)
-    let label = ''; // will be updated
-    let classname = 'sea-field-all'; // default
-    
-    if (propValue === undefined) {
-      // The "all" case.
-      label = this.presenter.getAllEntriesLabel(propName);
-      // classname remains at default
-    }
-    else {
-      const propDef = props[propName];
-      const propUri = propDefToVocabUri(propDef);
-
-      if (vocabs !== undefined && propUri) {
-        // This is a vocab field.
-        label = vocabs.getTerm(propValue, lang);
-        classname = `sea-field-${uriToTag(propValue)}`;
-      } else {
-        // The value comes from the data directly
-        // label from propValue
-        label = propValue;
-        classname = `sea-field-${labelToTag(propValue)}`;
-      }
-    }
-
-    if (!initiativeListSidebar.empty() && !sidebarButton.empty()) {
-      initiativeListSidebar.insert(() => sidebarButton.node(),
-                                   "#sea-initiatives-list-sidebar-content");
-      const seaFieldClasses = initiativeListSidebar.attr("class")
-        .split(/\s+/).filter(c => c.match(/^sea-field-/));
-      initiativeListSidebar.classed(seaFieldClasses.join(' '), false);
-      initiativeListSidebar.classed(classname, true);
-    }
-    
-    this.presenter.parent.mapui.changeFilters(propName, propValue);
-
-    //setup sidebar buttons in initiative list
-    const sidebarBtnHolder = selection.append("div").attr("class", "initiative-list-sidebar-btn-wrapper");
-
-
-    sidebarBtnHolder
-      .append("button")
-      .attr("class", "w3-button w3-border-0 initiative-list-sidebar-btn")
-      .attr("title", labels.showSearch)
-      .on("click", function () {
-
-        EventBus.Sidebar.hideInitiativeList.pub();
-        EventBus.Markers.needToShowLatestSelection.pub([]);
-        EventBus.Sidebar.showInitiatives.pub();
-      })
-      .append("i")
-      .attr("class", "fa fa-search");
-
-
-
-    sidebarBtnHolder
-      .append("button")
-      .attr("class", "w3-button w3-border-0")
-      .attr("title", labels.showInfo)
-      .on("click", function () {
-        EventBus.Sidebar.hideInitiativeList.pub();
-        EventBus.Markers.needToShowLatestSelection.pub([]);
-        EventBus.Sidebar.showAbout.pub();
-      })
-      .append("i")
-      .attr("class", "fa fa-info-circle");
-
-
-
-    if (true) {
-      sidebarBtnHolder
-        .append("button")
-        .attr("class", "w3-button w3-border-0")
-        .attr("title", labels.showDatasets)
-        .on("click", function () {
-          EventBus.Sidebar.hideInitiativeList.pub();
-          EventBus.Markers.needToShowLatestSelection.pub([]);
-          EventBus.Sidebar.showDatasets.pub();
-        })
-        .append("i")
-        .attr("class", "fa fa-database");
-    }
-
-
-
-    sidebarBtnHolder
-      .append("button")
-      .attr("class", "w3-button w3-border-0 ml-auto sidebar-button")
-      .attr("title", labels.close + label)
-      .on("click", () => {
-        this.presenter.removeFilters(propName);
-      })
-      .append("i")
-      .attr("class", "fa " + "fa-times");
-
-
-
-    selection
-      .append("button")
-      .attr("class", "w3-button w3-border-0 ml-auto sidebar-button sidebar-normal-size-close-btn")
-      .attr("title", labels.close + label)
-      .on("click", () => {
-        this.presenter.removeFilters(propName);
-      })
-      .append("i")
-      .attr("class", "fa " + "fa-times");
-
-    selection
-      .append("h2")
-      .classed("sea-field", true)
-      .text(label)
-      .on("click", () => {
-        this.presenter.notifyMapNeedsToNeedsToBeZoomedAndPanned(initiatives);
-      });
-    const list = selection.append("ul").classed("sea-initiative-list", true);
-    for (let initiative of initiatives) {
-      let activeClass = "";
-      let nongeoClass = "";
-      if (this.presenter.parent.mapui.isSelected(initiative)) {
-        activeClass = "sea-initiative-active";
-      }
-
-      if (!initiative.hasLocation()) {
-        nongeoClass = "sea-initiative-non-geo";
-      }
-
-      list
-        .append("li")
-        .text(_toString(initiative.name))
-        .attr("data-uid", _toString(initiative.uri))
-        .classed(activeClass, true)
-        .classed(nongeoClass, true)
-        .on("click", function () {
-          EventBus.Directory.initiativeClicked.pub(initiative);
-        })
-        .on("mouseover", () => {
-          this.presenter.onInitiativeMouseoverInSidebar(initiative);
-        })
-        .on("mouseout", () => {
-          this.presenter.onInitiativeMouseoutInSidebar(initiative);
-        });
-
-
-    }
-    sidebar
-      .on(
-        "transitionend",
-        (event: TransitionEvent) => {
-          const target = event.target as HTMLElement | null | undefined; // Need some coercion here
-          if (target?.className === "w3-btn")
-            return;
-          if (event.propertyName === "transform")
-            this.presenter.parent.view.updateSidebarWidth();
-        },
-        false
-      )
-      .classed("sea-sidebar-list-initiatives", true);
-  }
-
-  populateInitiativeSidebar(initiative: Initiative, initiativeContent: string) {
-    // Highlight the correct initiative in the directory
-    d3.select(".sea-initiative-active").classed("sea-initiative-active", false);
-    d3.select('[data-uid="' + initiative.uri + '"]').classed(
-      "sea-initiative-active",
-      true
-    );
-    let initiativeSidebar = d3.select("#sea-initiative-sidebar");
-    let initiativeContentElement = this.d3selectAndClear(
-      "#sea-initiative-sidebar-content"
-    );
-    initiativeContentElement
-      .append("button")
-      .attr("class", "w3-button w3-border-0 ml-auto sidebar-button")
-      .attr("title", `${this.presenter.parent.mapui.labels.close} ${initiative.name}`)
-      .on("click", function () {
-        EventBus.Directory.initiativeClicked.pub(undefined);
-      })
-      .append("i")
-      .attr("class", "fa " + "fa-times");
-    initiativeContentElement
-      .append("div")
-      .html(initiativeContent);
-    initiativeSidebar.classed("sea-initiative-sidebar-open", true);
-    // if (document.getElementById("map-app-leaflet-map").clientWidth < 800)
-    if (window.outerWidth < 800)
-      EventBus.Sidebar.showSidebar.pub();
-  }
-
-  deselectInitiativeSidebar() {
-    d3.select(".sea-initiative-active").classed("sea-initiative-active", false);
-    let initiativeSidebar = d3.select("#sea-initiative-sidebar");
-    // let initiativeContentElement = d3.select("#sea-initiative-sidebar-content");
-    // initiativeContentElement.html(initiativeContent);
-    initiativeSidebar.classed("sea-initiative-sidebar-open", false);
-    d3.select(".sea-search-initiative-active")
-      .classed("sea-search-initiative-active", false);
-  }
-  
 }

--- a/src/map-app/app/view/sidebar/directory.ts
+++ b/src/map-app/app/view/sidebar/directory.ts
@@ -140,7 +140,7 @@ export class DirectorySidebarView extends BaseSidebarView {
         .classed(classname, true)
         .classed("sea-directory-field", true)
         .on("click", (event: MouseEvent) => {
-          this.presenter.parent.mapui.resetSearch();
+          this.presenter.parent.mapui.clearFiltersAndSearch();
           this.presenter.parent.mapui.changeFilters(propName, propValue);
           EventBus.Sidebar.showInitiativeList.pub();
           this.resetFilterSearch();

--- a/src/map-app/eventbus.ts
+++ b/src/map-app/eventbus.ts
@@ -18,8 +18,6 @@ export namespace EventBus {
     //export const filterDataset = new PostalEvent<Data>("Datasets.filterDataset");
   }
   export namespace Directory {
-	  export const initiativeClicked = new PostalTopic<Initiative|undefined>("Directory.initiativeClicked"); // deselected if undefined
-	  export const initiativeClickedHideSidebar = new PostalTopic<Initiative>("Directory.InitiativeClickedSidebar.hideSidebar");
   }
   export namespace Initiatives {
     export interface DatasetError { error: Error; dataset?: string; }
@@ -32,8 +30,6 @@ export namespace EventBus {
   export namespace Initiative {
     export const created = new PostalTopic<Initiative>("Initiative.created");
 	  export const refreshed = new PostalTopic<Initiative>("Initiative.refreshed");
-	  export const searchedInitiativeClicked = new PostalTopic<Initiative>("Initiative.searchedInitiativeClicked");
-	  //export const selected = new PostalTopic<Data>("Initiative.selected");
   }
   export namespace Map {
     export interface ZoomOptions {
@@ -77,7 +73,9 @@ export namespace EventBus {
 	  export const needToShowInitiativeTooltip = new PostalTopic<Initiative>("Map.needToShowInitiativeTooltip");
 	  export const needsToBeZoomedAndPanned = new PostalTopic<SelectAndZoomData>("Map.needsToBeZoomedAndPanned");
 	  export const selectAndZoomOnInitiative = new PostalTopic<SelectAndZoomData>("Map.selectAndZoomOnInitiative");
+    export const initiativeClicked = new PostalTopic<Initiative|undefined>("Map.initiativeClicked");
 	  export const setActiveArea = new PostalTopic<ActiveArea>("Map.setActiveArea");
+    export const resetSearch = new PostalTopic("Map.resetSearch");
   }
   export namespace Marker {
 	  export const selectionToggled = new PostalTopic<Initiative>("Marker.SelectionToggled");
@@ -87,7 +85,7 @@ export namespace EventBus {
 	  export const needToShowLatestSelection = new PostalTopic<Initiative[]>("Markers.needToShowLatestSelection");
   }
   export namespace Sidebar {
-	  export const hideInitiative = new PostalTopic("Sidebar.hideInitiative");
+    export const showInitiativeList = new PostalTopic("Sidebar.showInitiativeList");
 	  export const hideInitiativeList = new PostalTopic("Sidebar.hideInitiativeList");
 	  export const hideInitiativeSidebar = new PostalTopic("Sidebar.hideInitiativeSidebar");
 	  export const hideSidebar = new PostalTopic("Sidebar.hideSidebar");

--- a/src/map-app/eventbus.ts
+++ b/src/map-app/eventbus.ts
@@ -75,7 +75,7 @@ export namespace EventBus {
 	  export const selectAndZoomOnInitiative = new PostalTopic<SelectAndZoomData>("Map.selectAndZoomOnInitiative");
     export const initiativeClicked = new PostalTopic<Initiative|undefined>("Map.initiativeClicked");
 	  export const setActiveArea = new PostalTopic<ActiveArea>("Map.setActiveArea");
-    export const resetSearch = new PostalTopic("Map.resetSearch");
+    export const clearFiltersAndSearch = new PostalTopic("Map.clearFiltersAndSearch");
   }
   export namespace Marker {
 	  export const selectionToggled = new PostalTopic<Initiative>("Marker.SelectionToggled");

--- a/src/map-app/index.ts
+++ b/src/map-app/index.ts
@@ -122,43 +122,52 @@ export function webRun(window: Window, base_config: ConfigData): void {
   mapApp.innerHTML = `
       <!-- Page Content -->
       <div class="w3-teal map-app-content">
+
         <!-- Sidebar -->
         <div class="sea-sidebar" style="flex-direction:column;" id="map-app-sidebar">
+
           <!--  Button to show sidebar -->
           <div id="map-app-sidebar-button" class="map-app-sidebar-button">
           </div>
+          
+          <!--  Panel in sidebar which shows filtered results. This doesn't always show and can be closed. -->
           <div class="w3-bar-block sea-initiatives-list-sidebar" id="sea-initiatives-list-sidebar">
             <div class="sea-initiatives-list-sidebar-content" id="sea-initiatives-list-sidebar-content">
             </div>
           </div>
+
+          <!-- Fixed part of sidebar. Content depends on what is chosen in the sidebar header (e.g. directory, search) -->
           <div class="w3-bar-block sea-main-sidebar">
+            
             <div class="sea-main-sidebar-inner">
               <div id="map-app-sidebar-header" class="map-app-sidebar-header">
               </div>
             </div>
-            <!-- Fixed part of Sidebar that may change for different types of the sidebar (e.g. Search results) -->
+
             <!-- If this is not a separate flex div, then it doesn't quite render properly on iPhone:
                 the bottom of the div slightly overlaps the scrollable section of the sidebar below -->
             <div class="sea-main-sidebar-inner">
               <div id="map-app-sidebar-fixed-section" class="map-app-sidebar-fixed-section "></div>
             </div>
+
             <!-- scrollable part of sidebar -->
             <!-- occupies the remaining vertical space, with scrollbar added if needed. -->
             <div id="map-app-sidebar-scrollable-section" class="map-app-sidebar-scrollable-section">
             </div>
+
           </div>
+          
           <div class="w3-bar-block sea-initiative-sidebar" id="sea-initiative-sidebar">
             <div class="sea-initiative-sidebar-content" id="sea-initiative-sidebar-content">
             </div>
           </div>
+        
         </div>
+        
+        <!-- the actual Leaflet map -->
         <div class="map-app-map-container" id="map-app-leaflet-map">
         </div>
-        <div class="w3-display-container map-app-display-container">
-          <!--  Search box -->
-          <div id="map-app-search-widget">
-          </div>
-        </div>
+        
       </div>`;
 
   const attrs = parseAttributes(mapApp, base_config.attr_namespace || '');

--- a/src/map-app/localisations.ts
+++ b/src/map-app/localisations.ts
@@ -40,6 +40,7 @@ export interface PhraseBook {
   allEntries: string;
   and: string;
   any: string;
+  applyFilters: string;
   clearFilters: string;
   clickToSearch: string;
   clickForDetailsHereAndMap: string;
@@ -49,11 +50,13 @@ export interface PhraseBook {
   countries: string;
   datasets: string;
   directory: string;
+  directoryEntries: string;
   errorLoading: string;
   hideDirectory: string;
   in: string;
   loading: string;
   mapDisclaimer: string;
+  matchingResults: string;
   mixedSources: string;
   noLocation: string;
   notAvailable: string;
@@ -87,20 +90,23 @@ export const phraseBooks: PhraseBooks = {
     allEntries: "All Entries",
     and: "AND",
     any: "Any",
+    applyFilters: "Apply filters",
+    clearFilters: "Clear filters",
     clickToSearch: "Click to search",
     clickForDetailsHereAndMap: "Click to see details here and on map",
-    clearFilters: "Clear Filters",
     close: "Close ",
     contact: "Contact",
     contributers: "contributers",
     countries: "Countries",
     datasets: "Datasets",
     directory: "Directory",
+    directoryEntries: "directory entries",
     errorLoading: "Error loading",
     hideDirectory: "Hide directory",
     in: "in",
     loading: "Loading",
     mapDisclaimer: "This map contains indications of areas where there are disputes over territories. The ICA does not endorse or accept the boundaries depicted on the map.",
+    matchingResults: "matching results",
     mixedSources: "Mixed Sources",
     noLocation: "No location available",
     notAvailable: "N / A",
@@ -129,6 +135,7 @@ export const phraseBooks: PhraseBooks = {
     allEntries: "Toutes les entrées",
     and: "ET",
     any: "Tout afficher",
+    applyFilters: "Appliquer les filtres",
     clearFilters: "Réinitialiser les filtres",
     clickToSearch: "Cliquez pour rechercher",
     clickForDetailsHereAndMap: "Cliquez pour voir les détails ici et sur la carte",
@@ -138,11 +145,13 @@ export const phraseBooks: PhraseBooks = {
     countries: "Des pays",
     datasets: "Ensembles de données",
     directory: "Annuaire",
+    directoryEntries: "entrées d'annuaire",
     errorLoading: "FIXME",
     hideDirectory: "Masquer l’annuaire",
     in: "dans",
     loading: "Chargement des données",
     mapDisclaimer: "Cette carte contient des indications sur les zones où il y a des différends au sujet territorial. L'ACI n'approuve ni n'accepte les frontières représentées sur la carte.",
+    matchingResults: "résultats correspondants",
     mixedSources: "Sources mixtes",
     noLocation: "Aucun emplacement disponible",
     notAvailable: "Pas disponible",
@@ -171,6 +180,7 @@ export const phraseBooks: PhraseBooks = {
     allEntries: "Todas las entradas",
     and: "Y",
     any: "Qualquiera",
+    applyFilters: "Aplicar filtros",
     clearFilters: "Borrar filtros",
     clickToSearch: "Haga clic para buscar",
     clickForDetailsHereAndMap: "Haga clic para ver detalles aquí y en el mapa",
@@ -180,11 +190,13 @@ export const phraseBooks: PhraseBooks = {
     countries: "Países",
     datasets: "Conjuntos de datos",
     directory: "Directorio",
+    directoryEntries: "entradas de directorio",
     errorLoading: "FIXME",
     hideDirectory: "Ocultar directorio",
     in: "en",
     loading: "Cargando…",
     mapDisclaimer: "Este mapa contiene indicaciones de zonas donde hay disputas territoriales. La ACI no respalda ni acepta las fronteras representadas en el mapa.",
+    matchingResults: "resultados coincidentes",
     mixedSources: "Fuentes mixtas",
     noLocation: "No hay ubicación disponible",
     notAvailable: "No disponible",
@@ -213,6 +225,7 @@ export const phraseBooks: PhraseBooks = {
     allEntries: "모든 항목들",
     and: "그리고",
     any: "아무거나",
+    applyFilters: "필터 적용",
     clearFilters: "필터 지우기",
     clickToSearch: "클릭하여 검색",
     clickForDetailsHereAndMap: "여기와 지도에서 세부정보를 보려면 클릭하세요.",
@@ -222,11 +235,13 @@ export const phraseBooks: PhraseBooks = {
     countries: "국가",
     datasets: "데자료",
     directory: "디렉토리",
+    directoryEntries: "디렉토리 항목",
     errorLoading: "FIXME",
     hideDirectory: "디렉토리 숨기기",
     in: "에",
     loading: "로딩",
     mapDisclaimer: "이 지도에는 영토에 대한 분쟁이 있는 지역의 표시가 포함되어 있습니다. ICA는 지도에 표시된 경계를 승인하거나 수락하지 않습니다.",
+    matchingResults: "일치하는 결과",
     mixedSources: "혼합",
     noLocation: "사용 가능한 위치 없음",
     notAvailable: "사용 불가",

--- a/src/map-app/styles/style.css
+++ b/src/map-app/styles/style.css
@@ -127,10 +127,8 @@ body {
 }
 
 /* All */
-.sea-initiatives-list-sidebar.sea-field-all,
-.sea-field-all .sea-initiatives-list-sidebar-content,
-.sea-field-all:hover,
-.sea-field-all.sea-field-active {
+.sea-initiatives-list-sidebar,
+.sea-initiatives-list-sidebar-content {
   background: var(--dark) !important;
 }
 
@@ -163,8 +161,15 @@ body {
   color: #ccc; 
 }
 
-.sidebar-button-container{
-  margin-top: 5px;
+.apply-filters-button-container{
+  margin-top: 28px;
+}
+
+.apply-filters-button{
+  border: solid;
+  border-width: 2px;
+  font-weight: 450;
+  font-size: 0.9rem;
 }
 
 /* Arts, Media, Culture & Leisure. */
@@ -376,7 +381,7 @@ body {
   transform: translateX(-100%);
   transition: transform 0.16s cubic-bezier(0.215, 0.61, 0.355, 1);
   font-family: var(--sea-font-family-sans-serif);
-  font-weight: 300;
+  font-weight: 250;
   color: var(--dark);
   background: white;
 }
@@ -407,7 +412,7 @@ body {
   display: flex;
   flex-direction: column;
   padding: 0 0 1.4em;
-  font-weight: 400;
+  font-weight: 300;
 }
 .sea-initiatives-list-sidebar-content {
   height: 100%;
@@ -433,10 +438,6 @@ body {
   transform: translateX(-100%);
 }
 
-.sea-sidebar-open.sea-sidebar-list-initiatives .sea-initiatives-list-sidebar {
-  transform: translateX(var(--sidebar-width));
-}
-
 .sea-initiatives-list-sidebar {
   right: 0;
   background-color: var(--dark);
@@ -458,11 +459,12 @@ body {
   font-size: 1.4rem;
 }
 
-.sea-sidebar h2.sea-field {
-  padding: 0.5rem 1rem 0.7rem;
+.sea-sidebar p.filter-count {
+  padding: 0.5rem 1rem 0.7rem 1.25rem;
   margin: 0;
-  line-height: 1.3;
   font-size: 1.3rem;
+  font-weight: 500;
+  cursor: default;
 }
 
 .sea-sidebar h3 {
@@ -471,9 +473,6 @@ body {
 }
 
 /* Map */
-.map-app-display-container {
-  z-index: 30;
-}
 
 div.map-app-map-container {
   overflow: hidden;
@@ -492,6 +491,10 @@ div.map-app-map-container {
   margin-top: 1em;
 }
 
+.sea-sidebar-open.sea-sidebar-list-initiatives .map-app-sidebar-button {
+  transform: translateX(var(--sidebar-width));
+}
+
 .map-app-sidebar-button button {
   padding: 0 0.45em;
   font-size: 2.4em;
@@ -501,9 +504,12 @@ div.map-app-map-container {
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 }
 
+.map-app-sidebar-button button:hover {
+  transform: translateX(0px);
+}
+
 .w3-btn:hover {
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
-  transform: translateX(0px);
 }
 
 .map-app-sidebar-header {
@@ -549,21 +555,21 @@ input[type="search"] {
 }
 
 .sea-directory-list,
-.sea-initiative-list {
+.sea-initiatives-list {
   list-style: none;
   font-size: 1.05em;
   padding: 0;
   margin: 0 0 1.6em;
 }
 
-.sea-initiative-list {
+.sea-initiatives-list {
   margin: 0;
   overflow-y: scroll;
   -webkit-overflow-scrolling: touch;
 }
 
 .sea-directory-list li,
-.sea-initiative-list li {
+.sea-initiatives-list li {
   margin: 0;
   padding: 0.4rem 1rem 0.4rem 1.25rem;
   user-select: none;
@@ -574,10 +580,9 @@ input[type="search"] {
   color: white;
   background-color: var(--dark);
   cursor: pointer;
-  /* font-weight: 400; */
 }
 
-.sea-initiative-list li:hover,
+.sea-initiatives-list li:hover,
 .sea-sidebar h2.sea-field:hover {
   color: var(--dark);
   background-color: white;
@@ -587,11 +592,6 @@ input[type="search"] {
 .sea-initiative-active {
   color: var(--dark);
   background-color: white;
-}
-
-.sea-search-initiative-active {
-  color: white;
-  background-color: var(--dark);
 }
 
 .ml-auto {
@@ -609,6 +609,15 @@ input[type="search"] {
 .map-app-search-form {
   max-width: 300px;
   width: 100%;
+}
+
+.map-app-search-filter-count p {
+  font-size: 1.2rem;
+  color: var(--dark);
+}
+
+.map-app-search-filter-count .filter-count-value {
+  color: var(--maroon);
 }
 
 .sea-sidebar,
@@ -707,7 +716,7 @@ input[type="search"] {
 
 .sea-initiative-popup p,
 .sea-initiative-sidebar-content p {
-  font-weight: 300;
+  font-weight: 250;
   font-size: 0.9rem;
   margin: 0.5rem 0;
 }
@@ -723,28 +732,38 @@ input[type="search"] {
   margin-top: 0.7rem;
 }
 
-@media (max-device-width: 1080px) {
-  .sea-initiatives-list-sidebar {
+@media (min-width:1081px) {
+  .mobile-only { display:none!important }
+}
+
+.sea-sidebar-open.sea-sidebar-list-initiatives .sea-initiatives-list-sidebar {
+  transform: translateX(var(--sidebar-width));
+}
+
+@media (max-width: 1080px) {
+  .sea-sidebar-open.sea-sidebar-list-initiatives {
+    /* on smaller screen, shift the main portion of the sidebar off the screen */
     transform: translateX(-100%);
     z-index: 100;
   }
 
-  .sea-sidebar-list-initiatives .sea-initiatives-list-sidebar {
-    transform: translateX(0%);
-  }
-
-  .sea-sidebar-open.sea-sidebar-list-initiatives .sea-initiatives-list-sidebar {
-    transform: translateX(0);
+  .sea-initiatives-list-sidebar {
+    transform: translateX(-100%);
+    z-index: 100;
   }
 }
 
-@media (max-device-width: 800px) {
+@media (max-width: 800px) {
   .sea-initiative-popup {
     display: none;
   }
 
   .sea-initiative-sidebar-open {
-    transform: translateX(0);
+    transform: translateX(0%);
+  }
+
+  .sea-sidebar-open.sea-sidebar-list-initiatives .sea-initiative-sidebar-open {
+    transform: translateX(100%);
   }
 }
 
@@ -830,21 +849,24 @@ input[type="search"] {
   text-align: center;
 }
 
-.initiative-list-sidebar-btn-wrapper {
-  display: none;
+.initiatives-list-sidebar-header {
+  display: flex;
+  justify-content: flex-start;
+  font-size: 1.4rem;
+  flex: 0 0 auto;
+  border-bottom: 1.5px solid var(--dark-gray);
+  margin-bottom: 0.7rem;
 }
 
-@media (max-device-width: 1080px) {
-  .initiative-list-sidebar-btn-wrapper {
-    display: flex;
-    justify-content: flex-start;
-    font-size: 1.4em;
-    flex: 0 0 auto; 
-  }
+.clear-filters-button {
+  font-size: 1rem;
+  text-decoration: underline;
+  margin-right: 1.2rem;
+  cursor: pointer;
+}
 
-  .sidebar-normal-size-close-btn {
-    display: none;
-  }
+.clear-filters-button:active {
+  color: var(--gray);
 }
 
 #logo-holder {
@@ -856,7 +878,7 @@ input[type="search"] {
 }
 
 /* Shrink the logo on small displays to avoit it overflowing */
-@media (max-device-width: 768px) {
+@media (max-width: 768px) {
   #logo-holder {
     height: 2.5rem;
   }

--- a/src/map-app/undo-stack.ts
+++ b/src/map-app/undo-stack.ts
@@ -39,7 +39,10 @@ export class WalkableStack1<T> {
     assert(this.storage.length > this.index, "storage should always have the initial state element");
     
     this.index += 1;
-    this.storage[this.index] = obj; // sets storage.length to index+1
+    this.storage[this.index] = obj;
+    
+    // remove later items from the stack
+    this.storage.length = this.index + 1; 
   }
 
   // Get the current item in the stack

--- a/src/map-app/utils.ts
+++ b/src/map-app/utils.ts
@@ -251,3 +251,23 @@ export function filterSet<T>(set: Set<T>, predicate: Predicate<T>): Set<T> {
   return result;
 }
 
+/**
+ * This matches with the value of `@media (width)` in the css on all browsers.
+ */
+export const getViewportWidth = () =>
+  Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0);
+
+/**
+ * We can display an expanded sidebar if the viewport is wide enough (over 1080 pixels), otherwise
+ * we collapse to a single sidebar.
+ */
+export const canDisplayExpandedSidebar = () =>
+  getViewportWidth() > 1080;
+
+
+  /**
+ * We can display initiative popups if the viewport is wide enough (over 800 pixels), otherwise we
+ * display the info in the sidebar.
+ */
+export const canDisplayInitiativePopups = () =>
+  getViewportWidth() > 800;


### PR DESCRIPTION
Closes #230 

The main change here is to generalise the dark initiatives list panel used in DirectorySidebarView, to also be used to display the list of initiatives that match a search. In that process of moving code over to the abstract class, I also spotted a lot of unnecessary duplicated code in the child classes, which I removed.

This code to create the initiatives list panel has been moved to BaseSidebarView, and a count of results has been added to its header. It should appear whenever a search is performed or a directory item is clicked.

For smaller screens with a width of < 1080 pixels, the panel only displays once 'apply filters' has been clicked, since it appears in front of the sidebar. The logic and css for detecting smaller screens has been fixed up since it was a bit inconsistent.
