### PR TITLE
DotCoop - Display the names of orgs an entity is a 'member of' in marker popup

### DIFF
--- a/src/map-app/app/view/map/marker.ts
+++ b/src/map-app/app/view/map/marker.ts
@@ -22,7 +22,7 @@ export class MapMarkerView extends BaseView {
     // options argument overrides our default options:
     const opts = Object.assign(this.dfltOptions, {
       // icon: this.presenter.getIcon(initiative),
-      popuptext: this.presenter.getInitiativeContent(initiative)
+      getPopupText: () => this.presenter.getInitiativeContent(initiative)
     });
 
     // For non-geo initiatives we don't need a marker but still want to get the initiativeContent
@@ -47,7 +47,7 @@ export class MapMarkerView extends BaseView {
 
       initiative.__internal.marker = this.marker;
 
-      this.marker.bindPopup(opts.popuptext, {
+      this.marker.bindPopup(opts.getPopupText, {
         autoPan: false,
         minWidth: 472,
         maxWidth: 472,
@@ -83,7 +83,7 @@ export class MapMarkerView extends BaseView {
 
       // maxWidth helps to accomodate big font, for presentation purpose, set up in CSS
       // maxWidth:800 is needed if the font-size is set to 200% in CSS:
-      this.marker.bindPopup(opts.popuptext, {
+      this.marker.bindPopup(opts.getPopupText, {
         autoPan: false,
         //minWidth: "472",
         //maxWidth: "800",


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/DigitalCommons/dotcoop-project/issues/66

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
We need to change the way that popup content is loaded, so that it is dynamic, rather than done once when the data is first loaded. This is since the 'member of' field needs to search through all the loaded initiatives to match UID to name.